### PR TITLE
Returning all raw data from get_qwdata and get_gwleveles

### DIFF
--- a/dataretrieval/utils.py
+++ b/dataretrieval/utils.py
@@ -54,9 +54,9 @@ def format_datetime(df, date_field, time_field, tz_field):
     #create a datetime index from the columns in qwdata response
     df[tz_field] = df[tz_field].map(tz)
 
-    df['datetime'] = pd.to_datetime(df.pop(date_field) + ' ' +
-                                    df.pop(time_field) + ' ' +
-                                    df.pop(tz_field),
+    df['datetime'] = pd.to_datetime(df[date_field] + ' ' +
+                                    df[time_field] + ' ' +
+                                    df[tz_field],
                                     format = '%Y-%m-%d %H:%M',
                                     utc=True)
 

--- a/tests/waterservices_test.py
+++ b/tests/waterservices_test.py
@@ -121,7 +121,7 @@ def test_get_qwdata(requests_mock):
     mock_request(requests_mock, request_url, response_file_path)
     df, md = get_qwdata(sites=["01491000", "01645000"])
     assert type(df) is DataFrame
-    assert df.size == 1650709
+    assert df.size == 1821472
     assert_metadata(requests_mock, request_url, md, site, None, format)
 
 
@@ -135,7 +135,7 @@ def test_get_gwlevels(requests_mock):
     mock_request(requests_mock, request_url, response_file_path)
     df, md = get_gwlevels(sites=[site])
     assert type(df) is DataFrame
-    assert df.size == 13
+    assert df.size == 16
     assert_metadata(requests_mock, request_url, md, site, None, format)
 
 


### PR DESCRIPTION
This addresses issue #27 by modifying the function that parses date and time from get_qwdata and get_gwleveles avoiding data loss.